### PR TITLE
remove imports JsonIgnore desnecessario

### DIFF
--- a/src/main/java/com/api/pedidosApi/models/Categoria.java
+++ b/src/main/java/com/api/pedidosApi/models/Categoria.java
@@ -1,6 +1,5 @@
 package com.api.pedidosApi.models;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 
 import javax.persistence.*;

--- a/src/main/java/com/api/pedidosApi/models/Produto.java
+++ b/src/main/java/com/api/pedidosApi/models/Produto.java
@@ -1,7 +1,6 @@
 package com.api.pedidosApi.models;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import javax.persistence.*;
 import javax.validation.constraints.Min;


### PR DESCRIPTION
Remover imports desnecessarios da anotação @JsonIgnore nas entidades categoria e produtos.