### PR TITLE
adiciona relacionamento entre cidade e estado

### DIFF
--- a/src/main/java/com/api/pedidosApi/models/Cidade.java
+++ b/src/main/java/com/api/pedidosApi/models/Cidade.java
@@ -1,10 +1,11 @@
 package com.api.pedidosApi.models;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import com.fasterxml.jackson.annotation.JsonBackReference;
+
+import javax.persistence.*;
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 public class Cidade implements Serializable {
@@ -15,6 +16,10 @@ public class Cidade implements Serializable {
     private Integer id;
 
     private String nome;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "estado_id")  // Chave estrangeira para Estado
+    private Estado estado;
 
     public Cidade(){
 

--- a/src/main/java/com/api/pedidosApi/models/Estado.java
+++ b/src/main/java/com/api/pedidosApi/models/Estado.java
@@ -1,10 +1,11 @@
 package com.api.pedidosApi.models;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
+
+import javax.persistence.*;
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 public class Estado implements Serializable {
@@ -13,6 +14,9 @@ public class Estado implements Serializable {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
     private String nome;
+
+    @OneToMany(mappedBy = "estado", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+    private List<Cidade> cidades;
 
     public Estado(){
 


### PR DESCRIPTION
Adiciona relacionamento entre estado e cidade do tipo @OneToMany em estado e @ManyToOne em cidade
espera-se que ao consultar o framework retorne estados com as suas devidas  cidades.
Fazer a chamada no postman pelo endpoint 'estados'.